### PR TITLE
Use library() instead of require()

### DIFF
--- a/get-a-unimodal-network.md
+++ b/get-a-unimodal-network.md
@@ -94,12 +94,12 @@ Now run this command the same way you ran the previous commands.
 
 [5]: images/get-a-unimodal-network/install-projector.png
 
-## 6. Require projectoR
+## 6. Load projectoR
 
 Even though we've installed projectoR, we haven't loaded it into our current RStudio session. (RStudio only imports packages as you need them, in order to save memory.) Let's tell RStudio that we'll be using projectoR by typing
 
 ``
-require(projectoR)
+library(projectoR)
 ``
 
 And, of course, run that line just as you did the previous lines.


### PR DESCRIPTION
This is such a great tutorial for first-time R users who just need to get in and get out quickly ;) I'd suggest one pedantic, but maybe important change: use `library()` instead of `require()` 

You can find a [complete (and well-written) explanation of the reasoning here](http://yihui.name/en/2014/07/library-vs-require/), but TL;DR: `library()` will throw up a big red error message if `projectoR` can't be properly loaded (and will thus stop any further code execution), while `require()` will only raise a warning, and everything else will keep running. If anything goes wrong with `devtools::install_github(...)`, then you'll want that extra bit of error-checking that will alert the user if `projectoR` didn't quite get installed.

Since you're just running the code interactively here (i.e. running one line at a time within an IDE), it's not a huge deal. But if someone starts coding in R a bit more, they may start running more code non-interactively, and so they should get into the habit of using `library()` instead of `require()`

I changed two of the code references in this file, but you'd also need to change the screenshot if you want to complete the modifications @_@
