### PR TITLE
Minor link/wording changes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,11 +36,11 @@ Other kinds of relationships you could describe in an edge list:
 
 ... and on and on. The important thing here is that your edge list should contain a list of relationships between, at most, two kinds of entities (e.g., actors and films, people and preferences, people and books). The *nature* of those relationships can differ. For example, Person A could have *written* Book A, while Person B *published* Book A. But there should be two different kinds of things, at most, described in two columns.
 
-If you need specific guidance on setting up your edge list, you can find it [here](preparing-data-1-making-an-edge-list.md).
+If you need specific guidance on setting up your edge list, see [Preparing Data 1: Making an Edge List](preparing-data-1-making-an-edge-list.md).
 
 You can save your spreadsheet as an Excel document (with the file extension .xls) or its generic equivalent, a CSV (with the file extension .csv). Cytoscape can interpret both of these formats.
 
-If you don't have your own data, you can use the sample edgelist located [here](data/edgelist.csv).
+If you don't have your own data, you can use the [sample edgelist](data/edgelist.csv) included in this tutorial. (Use the "raw" download link or download the [CSV](https://raw.githubusercontent.com/miriamposner/cytoscape_tutorials/master/data/edgelist.csv) directly.)
 
 ![][1]
 


### PR DESCRIPTION
We used your tutorials in a workshop yesterday at Princeton CDH, and a less technical person at my table seemed to be struggling a bit with downloading the raw CSV vs the html representation, so I added a little more help text and a link directly to the CSV file. (I couldn't figure out a way to do a relative link to the raw CSV, but if you're not changing it I think this should be fine).  Also, when I went back into the document to help him download the file the repeated 'here' links were hard to differentiate.
